### PR TITLE
Add GitHub VS Code extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
 				"yzhang.markdown-all-in-one",
 				"DavidAnson.vscode-markdownlint",
 				"bierner.markdown-emoji",
-				"streetsidesoftware.code-spell-checker"
+				"streetsidesoftware.code-spell-checker",
+				"GitHub.vscode-pull-request-github"
 			]
 		}
 	},


### PR DESCRIPTION
Adds GitHub Visual Studio Code extension to devcontainer:
https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github