### PR TITLE
Adds deprecation banner to TopoMojo and Gameboard documentation pages

### DIFF
--- a/docs/gameboard/admin-clone-yaml-json.md
+++ b/docs/gameboard/admin-clone-yaml-json.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Clone, yaml, and json options
 
 **Clone:** Creates a copy of the game that replicates most of the original game.

--- a/docs/gameboard/admin-feedback-form.md
+++ b/docs/gameboard/admin-feedback-form.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Feedback Form
 
 In the Gameboard application, it is possible to create feedback forms to capture participant feedback on the game and individual challenges. Collecting and analyzing participant feedback can help you refine and improve your games and challenges.

--- a/docs/gameboard/admin-observe.md
+++ b/docs/gameboard/admin-observe.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Observe Mode
 
 Observe mode allows a game administrator with the correct role to see participant VMs during a particular game. Observers do not have the ability to interact with, or interfere with, the VM they are observing.

--- a/docs/gameboard/admin-players.md
+++ b/docs/gameboard/admin-players.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 You must have the Admin Role to get to the Players screen in a game. Assuming you have been granted the appropriate role in the Gameboard, select **Admin**. Hover your mouse over an active game, then click **Players**.
 
 **Search:** The Search feature is relative to the screen you are viewing when performing the search. You can apply the following filters to your search results and take action(s).

--- a/docs/gameboard/admin-practice-area.md
+++ b/docs/gameboard/admin-practice-area.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Admin Practice Area
 
 Gameboard administrators configure the global Practice Area context here. In the main navigation bar, click **Admin**, then **Practice Area**.

--- a/docs/gameboard/admin-roles.md
+++ b/docs/gameboard/admin-roles.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Gameboard Roles
 
 The following is a list of roles in the gameboard. Note that these roles aren't additive -- they are independent. Therefore, each role has to be added individually and a single user can have multiple roles. Each assigned role only grants the privileges for that role. Roles do not inherit permissions from other roles.

--- a/docs/gameboard/admin-settings.md
+++ b/docs/gameboard/admin-settings.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Admin Game Settings
 
 You arrive at the **Admin Game Settings** by creating a new game or by editing an existing one. With the appropriate role granted to you, click **Admin** then either:

--- a/docs/gameboard/admin.md
+++ b/docs/gameboard/admin.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Gameboard Administration
 
 The Admin function of Gameboard helps those with the admin role:

--- a/docs/gameboard/completion-certificates.md
+++ b/docs/gameboard/completion-certificates.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Completion Certificates
 
 Gameboard supports a convenient way for participants to view and print a certificate as proof that they participated in a game. Certificates are unique to the participant and specific to a game.

--- a/docs/gameboard/game-center.md
+++ b/docs/gameboard/game-center.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Game Center [BETA]
 
 The **Game Center** is the game admin's one stop shop when administering a live game. The Game Center unifies various Gameboard administrative and support elements such as game and challenge settings, player information, live sessions, support tickets, observe mode, and more.

--- a/docs/gameboard/getting-started.md
+++ b/docs/gameboard/getting-started.md
@@ -1,0 +1,3 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>

--- a/docs/gameboard/index.md
+++ b/docs/gameboard/index.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # About the Gameboard
 
 Developed by Carnegie Mellon University's [Software Engineering Institute](github.com/cmu-sei) (SEI), Gameboard is a flexible web platform that provides game design capabilities and a competition-ready user interface. The *Gameboard * explains how to implement it when you want to run your own cybersecurity game.

--- a/docs/gameboard/participating.md
+++ b/docs/gameboard/participating.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Participating in a Game
 
 This topic describes the Gameboard from a participant's point-of-view. A *participant* is a player in a game or a competitor in a competition who has no special role(s) attached them. These instructions assume that a fully configured game environment is available to the reader and they have an account on the Identity server.

--- a/docs/gameboard/practice-area.md
+++ b/docs/gameboard/practice-area.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Practice Area
 
 The **Practice Area** is where Gameboard players can go to rehearse challenges (labs) to become proficient in certain skills. Practice Area is a lightweight version of a formal competition. After logging into Gameboard, click **Practice** in the main navigation.

--- a/docs/gameboard/reports-beta.md
+++ b/docs/gameboard/reports-beta.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Reports
 
 The **Reports** module is available to users who have `Admin`, `Registrar`, or `Support` roles in the main navigation bar. Six report "cards" display available reports:

--- a/docs/gameboard/support.md
+++ b/docs/gameboard/support.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current Gameboard documentation [here](https://cmu-sei.github.io/crucible/gameboard/).</strong>
 # Using the Integrated Support feature
 
 The gameboard platform comes with a built-in customer support interface so that competition hosts and administrators can assist competitors and players. This way, Gameboard is a "one-stop shop" and no outside apps or systems are required to track and measure issues reported by participants.

--- a/docs/topomojo/admin-dashboard.md
+++ b/docs/topomojo/admin-dashboard.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin features
 
 TopoMojo has an admin interface called **Admin Dashboard**. To access the Admin Dashboard, you'll need the `admin` role. In the top-right corner, click the **Admin** button. The initial `admin` role is given to the first user who authenticates successfully.

--- a/docs/topomojo/admin-gamespaces.md
+++ b/docs/topomojo/admin-gamespaces.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Gamespaces
 
 The **Gamespaces** tab is where the admin can search for, and filter by, **active** and **inactive** gamespaces. Once gamespaces are found, the admin can perform certain actions. By default, the search is for *active* gamespaces. Green indicates *active* gamespaces and gray indicates *inactive* gamespaces.

--- a/docs/topomojo/admin-log.md
+++ b/docs/topomojo/admin-log.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Dashboard Log tab 
 
 The **Log** tab is useful from the admin point of view when trying to troubleshoot. Only errors are shown here, not every log line.

--- a/docs/topomojo/admin-machines.md
+++ b/docs/topomojo/admin-machines.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Machines
 
 This tab provides a list of all VMs TopoMojo is tracking and the gamespaces they are attached to without the use of the vSphere Client.

--- a/docs/topomojo/admin-templates.md
+++ b/docs/topomojo/admin-templates.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Templates
 
 The **Templates** tab is where you can view all of the templates that exist in TopoMojo.

--- a/docs/topomojo/admin-users.md
+++ b/docs/topomojo/admin-users.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Users
 
 The **Users** tab is where Topo users are listed, created, and assigned permissions. The **Search** feature allows Topo admins to search on the name of a Topo user. To search for a user across all of TopoMojo, enter the term into the **Search** field or filter by *role* or *audience*. 

--- a/docs/topomojo/admin-workspaces.md
+++ b/docs/topomojo/admin-workspaces.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Admin Workspaces
 
 The **Workspaces** tab is where the admin can search for workspaces and perform limited actions. Workspaces are where challenges (or labs) are built. Here, an admin can view every workspace.

--- a/docs/topomojo/building-a-workspace.md
+++ b/docs/topomojo/building-a-workspace.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Building a new workspace
 
 The workspace interface contains six tabs: Settings, Templates,  Document, Challenge, Files, and Play. To build a new Topo workspace click **Home**, then **New Workspace**.

--- a/docs/topomojo/challenge.md
+++ b/docs/topomojo/challenge.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Challenge tab
 
 The *Challenge* tab in the Topo workspace is used when both Gameboard and TopoMojo are integrated to execute a cyber competition. More information on linking those two applications together can be found elsewhere in the Foundry documentation. The Challenge tab is where you create random key/values, embed them in a *gamespace* at deploy time, and ask questions and answers of competitors (players).

--- a/docs/topomojo/copy-paste.md
+++ b/docs/topomojo/copy-paste.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Copy and paste
 
 The procedures below show you how to:

--- a/docs/topomojo/files.md
+++ b/docs/topomojo/files.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 The **Files** page in the Topo workspace allows you to upload files from your system to TopoMojo to include in your lab. These files are used as ISOs that can be attached to VMs in the workspace. If your files aren’t already in an ISO file format, TopoMojo wraps them in an ISO after upload.
 
 !!! note

--- a/docs/topomojo/finding-a-space.md
+++ b/docs/topomojo/finding-a-space.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Finding a space
 
 Once you're in Topo, you can browse for existing TopoMojo workspaces and gamespaces. In the left panel (`Ctrl-L`) , enter terms into the **Search** field. TopoMojo automatically searches for a workspace or a gamespace that matches your terms. Click **workspace** or **gamespace** to filter results. Topo labs are sorted alphabetically by name.

--- a/docs/topomojo/getting-started.md
+++ b/docs/topomojo/getting-started.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Getting started
 
 ## What's new

--- a/docs/topomojo/index.md
+++ b/docs/topomojo/index.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # TopoMojo Docs
 
 This documentation introduces users to the TopoMojo environment and provides information necessary to launch existing labs and create new topologies.

--- a/docs/topomojo/lab-document.md
+++ b/docs/topomojo/lab-document.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 # Lab Document
 
 The **Document** tab in a Topo workspace is where you write the instructions that correspond with your lab. Instructions are authored in Markdown using Topo's built-in editor. Authoring in Markdown enables you to create a nicely formatted document without writing HTML. 

--- a/docs/topomojo/play.md
+++ b/docs/topomojo/play.md
@@ -1,3 +1,6 @@
+!!! Warning "" 
+
+	 :warning: <strong>This documentation site has been deprecated and will no longer be updated as of 11/11/24. Foundry applications are now part of the [Crucible Framework](https://cmu-sei.github.io/crucible/). Please find current TopoMojo documentation [here](https://cmu-sei.github.io/crucible/topomojo/).</strong>
 The **Play** page is where you can interact with your lab in the same way others will when they launch your content or "play" through your challenge. Play deploys a read-only copy of all virtual machines in the workspace; this gives the player their own deployed configurations.
 
 **Variant:** Specify which variant of the challenge you wish to play (if it is a *variant* challenge).


### PR DESCRIPTION
We need to redirect users to the current Crucible documentation repo without breaking existing links to the Foundry docs repo. This PR adds a banner to every markdown file in TopoMojo and Gameboard documentation explaining that the site is deprecated and links to the Crucible pages.